### PR TITLE
feat: expressions as type parameters

### DIFF
--- a/DSL/de.unibonn.simpleml/model/SimpleML.ecore
+++ b/DSL/de.unibonn.simpleml/model/SimpleML.ecore
@@ -245,6 +245,7 @@
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="SmlTypeParameter" eSuperTypes="#//SmlAbstractNamedTypeDeclaration">
         <eStructuralFeatures xsi:type="ecore:EAttribute" name="variance" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString" />
+        <eStructuralFeatures xsi:type="ecore:EAttribute" name="kind" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString" />
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="SmlTypeArgumentList" eSuperTypes="#//SmlAbstractObject">
         <eStructuralFeatures xsi:type="ecore:EReference" name="typeArguments" upperBound="-1" eType="#//SmlTypeArgument" containment="true" />

--- a/DSL/de.unibonn.simpleml/model/SimpleML.genmodel
+++ b/DSL/de.unibonn.simpleml/model/SimpleML.genmodel
@@ -245,6 +245,7 @@
         </genClasses>
         <genClasses ecoreClass="SimpleML.ecore#//SmlTypeParameter">
             <genFeatures createChild="false" ecoreFeature="ecore:EAttribute SimpleML.ecore#//SmlTypeParameter/variance" />
+            <genFeatures createChild="false" ecoreFeature="ecore:EAttribute SimpleML.ecore#//SmlTypeParameter/kind" />
         </genClasses>
         <genClasses ecoreClass="SimpleML.ecore#//SmlTypeArgumentList">
             <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference SimpleML.ecore#//SmlTypeArgumentList/typeArguments" />

--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/SimpleML.xtext
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/SimpleML.xtext
@@ -384,7 +384,7 @@ SmlComparisonExpression returns SmlAbstractExpression
 
 SmlComparisonOperator
     : '<'
-    | '<=' 
+    | '<='
     | '>='
     | '>'
     ;
@@ -445,7 +445,7 @@ SmlLiteral returns SmlAbstractLiteral
     | SmlInt
     | SmlNull
     | SmlString
-    ;    
+    ;
 
 SmlBoolean
     : true?='true'
@@ -578,11 +578,22 @@ SmlTypeParameter
     : annotationCalls+=SmlAnnotationCall*
       variance=SmlTypeParameterVariance?
       name=ID
+      ('::' kind=SmlTypeParameterKind)?
     ;
 
 SmlTypeParameterVariance
     : 'in'
     | 'out'
+    ;
+
+SmlTypeParameterKind
+    : '$SchemaType'
+    | '$ExpressionType'
+    | '$IntType'
+    | '$FloatType'
+    | '$BooleanType'
+    | '$StringType'
+    | '$NamedType'
     ;
 
 SmlConstraintList

--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/constant/SmlKind.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/constant/SmlKind.kt
@@ -1,0 +1,31 @@
+package de.unibonn.simpleml.constant
+
+import de.unibonn.simpleml.simpleML.SmlTypeParameter
+
+/**
+ * The possible Kinds for an [SmlTypeParameter].
+ */
+enum class SmlKind(val kind: String?) {
+    NoKind(null),
+    SchemaKind("\$SchemaType"),
+    ExpressionKind("\$ExpressionType"),
+    IntKind("\$IntType"),
+    FloatKind("\$FloatType"),
+    BooleanKind("\$BooleanType"),
+    StringKind("\$StringType"),
+    NamedKind("\$NamedType");
+
+    override fun toString(): String {
+        return kind ?: "NoKind"
+    }
+}
+
+/**
+ * Returns the [SmlKind] of this [SmlTypeParameter].
+ *
+ * @throws IllegalArgumentException If the kind is unknown.
+ */
+fun SmlTypeParameter.kind(): SmlKind {
+    return SmlKind.values().firstOrNull { it.kind == this.kind }
+        ?: throw IllegalArgumentException("Unknown kind '$kind'.")
+}

--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/emf/Creators.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/emf/Creators.kt
@@ -4,6 +4,7 @@ package de.unibonn.simpleml.emf
 
 import de.unibonn.simpleml.constant.SmlFileExtension
 import de.unibonn.simpleml.constant.SmlInfixOperationOperator
+import de.unibonn.simpleml.constant.SmlKind
 import de.unibonn.simpleml.constant.SmlPrefixOperationOperator
 import de.unibonn.simpleml.constant.SmlProtocolQuantifiedTermQuantifier
 import de.unibonn.simpleml.constant.SmlProtocolTokenClassValue
@@ -1281,12 +1282,14 @@ fun createSmlTypeArgumentList(typeArguments: List<SmlTypeArgument>): SmlTypeArgu
 fun createSmlTypeParameter(
     name: String,
     annotationCalls: List<SmlAnnotationCall> = emptyList(),
-    variance: SmlVariance = SmlVariance.Invariant
+    variance: SmlVariance = SmlVariance.Invariant,
+    kind: SmlKind = SmlKind.NoKind
 ): SmlTypeParameter {
     return factory.createSmlTypeParameter().apply {
         this.name = name
         this.annotationCalls += annotationCalls
         this.variance = variance.variance
+        this.kind = kind.kind
     }
 }
 

--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/formatting2/SimpleMLFormatter.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/formatting2/SimpleMLFormatter.kt
@@ -16,6 +16,7 @@ import de.unibonn.simpleml.simpleML.SimpleMLPackage.Literals.SML_STEP__VISIBILIT
 import de.unibonn.simpleml.simpleML.SimpleMLPackage.Literals.SML_TYPE_ARGUMENT__TYPE_PARAMETER
 import de.unibonn.simpleml.simpleML.SimpleMLPackage.Literals.SML_TYPE_PARAMETER_CONSTRAINT__LEFT_OPERAND
 import de.unibonn.simpleml.simpleML.SimpleMLPackage.Literals.SML_TYPE_PARAMETER_CONSTRAINT__OPERATOR
+import de.unibonn.simpleml.simpleML.SimpleMLPackage.Literals.SML_TYPE_PARAMETER__KIND
 import de.unibonn.simpleml.simpleML.SimpleMLPackage.Literals.SML_TYPE_PARAMETER__VARIANCE
 import de.unibonn.simpleml.simpleML.SimpleMLPackage.Literals.SML_TYPE_PROJECTION__VARIANCE
 import de.unibonn.simpleml.simpleML.SimpleMLPackage.Literals.SML_YIELD__RESULT
@@ -1039,6 +1040,10 @@ class SimpleMLFormatter : AbstractFormatter2() {
 
                 // Feature "name"
                 doc.formatFeature(obj, SML_ABSTRACT_DECLARATION__NAME)
+
+                // Feature "kind"
+                doc.formatKeyword(obj, "::", oneSpace, oneSpace)
+                doc.formatFeature(obj, SML_TYPE_PARAMETER__KIND)
             }
             is SmlConstraintList -> {
 

--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/SimpleMLValidator.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/SimpleMLValidator.kt
@@ -15,6 +15,7 @@ import de.unibonn.simpleml.validation.declarations.ParameterListChecker
 import de.unibonn.simpleml.validation.declarations.PlaceholderChecker
 import de.unibonn.simpleml.validation.declarations.ResultChecker
 import de.unibonn.simpleml.validation.declarations.StepChecker
+import de.unibonn.simpleml.validation.declarations.TypeParameterChecker
 import de.unibonn.simpleml.validation.declarations.WorkflowChecker
 import de.unibonn.simpleml.validation.expressions.ArgumentChecker
 import de.unibonn.simpleml.validation.expressions.CallChecker
@@ -65,6 +66,7 @@ import org.eclipse.xtext.validation.ComposedChecks
         ResultChecker::class,
         WorkflowChecker::class,
         StepChecker::class,
+        TypeParameterChecker::class,
 
         NameConventionChecker::class,
 

--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/codes/ErrorCode.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/codes/ErrorCode.kt
@@ -90,5 +90,7 @@ enum class ErrorCode {
 
     WrongType,
 
+    VarianceAndKind,
+
     ExpertMustBeOptional
 }

--- a/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/declarations/TypeParameterChecker.kt
+++ b/DSL/de.unibonn.simpleml/src/main/kotlin/de/unibonn/simpleml/validation/declarations/TypeParameterChecker.kt
@@ -1,0 +1,25 @@
+package de.unibonn.simpleml.validation.declarations
+
+import de.unibonn.simpleml.constant.SmlKind
+import de.unibonn.simpleml.constant.SmlVariance
+import de.unibonn.simpleml.constant.kind
+import de.unibonn.simpleml.constant.variance
+import de.unibonn.simpleml.simpleML.SimpleMLPackage.Literals
+import de.unibonn.simpleml.simpleML.SmlTypeParameter
+import de.unibonn.simpleml.validation.AbstractSimpleMLChecker
+import de.unibonn.simpleml.validation.codes.ErrorCode
+import org.eclipse.xtext.validation.Check
+
+class TypeParameterChecker : AbstractSimpleMLChecker() {
+
+    @Check
+    fun nonStaticPropagates(smlTypeParameter: SmlTypeParameter) {
+        if (smlTypeParameter.variance() != SmlVariance.Invariant && smlTypeParameter.kind() != SmlKind.NoKind) {
+            error(
+                "Can not use variance and kind together",
+                Literals.SML_ABSTRACT_DECLARATION__NAME,
+                ErrorCode.VarianceAndKind
+            )
+        }
+    }
+}

--- a/DSL/de.unibonn.simpleml/src/test/resources/formatting/declarations/class.smltest
+++ b/DSL/de.unibonn.simpleml/src/test/resources/formatting/declarations/class.smltest
@@ -1,12 +1,13 @@
      class
    MyClass1
 
-          class    MyClass2 {  }      
+          class    MyClass2 {  }
 
    @Annotation1    @Annotation2            class   MyClass3
       < @AnnotationUse
             T1 ,   in
-      T2  ,   out  T3    >
+      T2  ,   out  T3, T4   ::  $SchemaType, T5     ::   $ExpressionType ,
+      T6  ::    $BooleanType   ,  T7     ::    $NamedType   >
          (
   @AnnotationUse
         a  :
@@ -25,7 +26,7 @@ class MyClass2 {}
 
 @Annotation1
 @Annotation2
-class MyClass3<@AnnotationUse T1, in T2, out T3>(@AnnotationUse a: Int, vararg b: Int = 3) sub SuperClass, SuperInterface where T2 super Number, T3 sub Number {
+class MyClass3<@AnnotationUse T1, in T2, out T3, T4 :: $SchemaType, T5 :: $ExpressionType, T6 :: $BooleanType, T7 :: $NamedType>(@AnnotationUse a: Int, vararg b: Int = 3) sub SuperClass, SuperInterface where T2 super Number, T3 sub Number {
     attr myAttribute1
 
     attr myAttribute2

--- a/DSL/de.unibonn.simpleml/src/test/resources/grammar/declarations/class.smltest
+++ b/DSL/de.unibonn.simpleml/src/test/resources/grammar/declarations/class.smltest
@@ -4,7 +4,7 @@ class MySimpleClass
 
 @AnnotationUse
 class MyComplexClass
-    <@AnnotationUse T1, in T2, out T3>
+    <@AnnotationUse T1, in T2, out T3, T4 :: $SchemaType, T5 :: $ExpressionType, T6 :: $IntType, T7 :: $FloatType, T8 :: $BooleanType, T9 :: $StringType, T10 :: $NamedType>
     (@AnnotationUse a: Int, vararg b: Int = 3)
     sub SuperClass1, SuperClass2
     where T2 super Number, T3 sub Number

--- a/DSL/de.unibonn.simpleml/src/test/resources/validation/declarations/typeParameters/varienceTogetherWithKind.smltest
+++ b/DSL/de.unibonn.simpleml/src/test/resources/validation/declarations/typeParameters/varienceTogetherWithKind.smltest
@@ -1,0 +1,6 @@
+package tests.validation.declarations.typeparameter.varienceTogether
+
+// semantic_error "Can not use variance and kind together"
+// no_semantic_error "Can not use variance and kind together"
+// no_semantic_error "Can not use variance and kind together"
+class Myclass <in »T1« :: $SchemaType, »T2« :: $ExpressionType, out »T3«>


### PR DESCRIPTION
Closes #28

Summary of Changes
Added the following expressions that can be used as type parameters.

$SchemaType
$ExpressionType
$IntType
$FloatType
$BooleanType
$StringType
$NamedType